### PR TITLE
Norminette/src/command

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -115,6 +115,9 @@ int				cmd_setup(t_cmd *cmd, t_env *env, char ***args,
 					char **full_path);
 void			cmd_init(char *rl, t_cmd *cmd, t_env *env);
 void			cmd_exec_inline(int argc, char **argv, t_env *env, t_cmd *cmd);
+void			cmd_exec_handle_redirect(t_cmdblock *block,
+					int *pipefd, int *fd_output);
+int				cmd_exec_setup_redirect(t_redirect *redirects);
 int				cmd_exec(t_cmd *cmd, t_env *env);
 void			cmd_debug(t_cmd *cmd);
 void			free_cmd(t_cmd *cmd);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -39,7 +39,8 @@ typedef struct s_env
 
 /* ================================= CMD =====================================*/
 
-typedef enum e_operator {
+typedef enum e_operator
+{
 	OP_NONE,
 	OP_PIPE,
 	OP_REDIR_IN,
@@ -48,7 +49,8 @@ typedef enum e_operator {
 	OP_HEREDOC
 }	t_operator;
 
-typedef struct s_redirect {
+typedef struct s_redirect
+{
 	t_operator			op_type;
 	char				*file;
 	struct s_redirect	*next;
@@ -115,9 +117,15 @@ int				cmd_setup(t_cmd *cmd, t_env *env, char ***args,
 					char **full_path);
 void			cmd_init(char *rl, t_cmd *cmd, t_env *env);
 void			cmd_exec_inline(int argc, char **argv, t_env *env, t_cmd *cmd);
+void			cmd_exec_setup_pipe(t_cmdblock *block, int *fd, int *prev_pipe);
 void			cmd_exec_handle_redirect(t_cmdblock *block,
 					int *pipefd, int *fd_output);
+int				cmd_exec_handle_heredoc(char *delimiter);
 int				cmd_exec_setup_redirect(t_redirect *redirects);
+int				cmd_exec_setup_heredoc(t_redirect *redirects, int *heredoc_fd);
+void			cmd_exec_pipe_cmd(t_cmd *cmd, t_env *env, int infd, int outfd);
+void			cmd_exec_pipe_wait_children(int *result);
+int				cmd_exec_pipe_check(t_cmd *cmdtmp, int *pipefd);
 int				cmd_exec(t_cmd *cmd, t_env *env);
 void			cmd_debug(t_cmd *cmd);
 void			free_cmd(t_cmd *cmd);

--- a/src/builtin/env.c
+++ b/src/builtin/env.c
@@ -12,6 +12,33 @@
 
 #include "minishell.h"
 
+char	**env_to_array(t_env *env)
+{
+	char	**env_array;
+	t_env	*current;
+	char	*tmp;
+	int		i;
+
+	i = -1;
+	current = env;
+	while (i++, current)
+		current = current->next;
+	env_array = malloc(sizeof(char *) * (i + 1));
+	if (!env_array)
+		return (NULL);
+	current = env;
+	i = -1;
+	while (i++, current)
+	{
+		tmp = ft_strjoin(current->key, "=");
+		env_array[i] = ft_strjoin(tmp, current->value);
+		free(tmp);
+		current = current->next;
+	}
+	env_array[i] = NULL;
+	return (env_array);
+}
+
 t_env	*env_init(char **envp)
 {
 	t_env	*env;
@@ -81,32 +108,6 @@ int	env_set(t_env *env, char *key, char *value, int plus)
 		new->value = ft_strdup(value);
 	new->next = NULL;
 	last->next = new;
-	return (0);
-}
-
-int	env_unset(t_env **env, char *key)
-{
-	t_env	*current;
-	t_env	*prev;
-
-	current = *env;
-	prev = NULL;
-	while (current)
-	{
-		if (ft_strncmp(current->key, key, ft_strlen(current->key)) == 0)
-		{
-			if (prev)
-				prev->next = current->next;
-			else
-				*env = current->next;
-			free(current->key);
-			free(current->value);
-			free(current);
-			return (1);
-		}
-		prev = current;
-		current = current->next;
-	}
 	return (0);
 }
 

--- a/src/builtin/unset.c
+++ b/src/builtin/unset.c
@@ -12,6 +12,32 @@
 
 #include "minishell.h"
 
+int	env_unset(t_env **env, char *key)
+{
+	t_env	*current;
+	t_env	*prev;
+
+	current = *env;
+	prev = NULL;
+	while (current)
+	{
+		if (ft_strncmp(current->key, key, ft_strlen(current->key)) == 0)
+		{
+			if (prev)
+				prev->next = current->next;
+			else
+				*env = current->next;
+			free(current->key);
+			free(current->value);
+			free(current);
+			return (1);
+		}
+		prev = current;
+		current = current->next;
+	}
+	return (0);
+}
+
 int	builtin_unset(t_cmd *cmd, t_env *env)
 {
 	int	i;

--- a/src/command/cmd_check.c
+++ b/src/command/cmd_check.c
@@ -29,23 +29,19 @@ static char	**get_paths(t_env *env)
 	return (paths);
 }
 
-char	*cmd_check(t_cmd *cmd, t_env *env)
+static char	*find_command_path(char **paths, char *cmd_name)
 {
 	char	*full_path;
 	char	*full_path_cmd;
-	char	**paths;
 	char	*result;
 	int		i;
 
-	paths = get_paths(env);
-	if (!paths)
-		return (NULL);
 	result = NULL;
 	i = -1;
 	while (paths[++i])
 	{
 		full_path = ft_strjoin(paths[i], "/");
-		full_path_cmd = ft_strjoin(full_path, cmd->cmd->exec);
+		full_path_cmd = ft_strjoin(full_path, cmd_name);
 		free(full_path);
 		if (access(full_path_cmd, X_OK) == 0)
 		{
@@ -54,6 +50,18 @@ char	*cmd_check(t_cmd *cmd, t_env *env)
 		}
 		free(full_path_cmd);
 	}
+	return (result);
+}
+
+char	*cmd_check(t_cmd *cmd, t_env *env)
+{
+	char	**paths;
+	char	*result;
+
+	paths = get_paths(env);
+	if (!paths)
+		return (NULL);
+	result = find_command_path(paths, cmd->cmd->exec);
 	free_array(paths);
 	if (!result)
 	{

--- a/src/command/cmd_exec.c
+++ b/src/command/cmd_exec.c
@@ -12,132 +12,7 @@
 
 #include "minishell.h"
 
-static int	handle_heredoc(char *delimiter)
-{
-	int		pipe_fd[2];
-	char	*line;
-	size_t	delim_len;
-
-	if (pipe(pipe_fd) == -1)
-		return (-1);
-	delim_len = ft_strlen(delimiter);
-	while (1)
-	{
-		line = readline("pipe heredoc> ");
-		if (!line)
-		{
-			close(pipe_fd[1]);
-			return (-1);
-		}
-		if (ft_strlen(line) == delim_len && ft_strcmp(line, delimiter) == 0)
-		{
-			free(line);
-			break ;
-		}
-		write(pipe_fd[1], line, ft_strlen(line));
-		write(pipe_fd[1], "\n", 1);
-		free(line);
-	}
-	close(pipe_fd[1]);
-	return (pipe_fd[0]);
-}
-
-static int	setup_redirections(t_redirect *redirects)
-{
-	t_redirect	*current;
-	int			fd;
-	int			heredoc_fd;
-
-	heredoc_fd = -1;
-	current = redirects;
-	while (current)
-	{
-		if (current->op_type == OP_HEREDOC)
-		{
-			heredoc_fd = handle_heredoc(current->file);
-			if (heredoc_fd == -1)
-				return (-1);
-		}
-		current = current->next;
-	}
-	current = redirects;
-	while (current)
-	{
-		if (current->op_type == OP_REDIR_IN)
-		{
-			fd = open(current->file, O_RDONLY);
-			if (fd == -1)
-				return (-1);
-			dup2(fd, STDIN_FILENO);
-			close(fd);
-		}
-		else if (current->op_type == OP_HEREDOC)
-		{
-			dup2(heredoc_fd, STDIN_FILENO);
-			close(heredoc_fd);
-		}
-		else if (current->op_type == OP_REDIR_OUT)
-		{
-			fd = open(current->file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-			if (fd == -1)
-				return (-1);
-			dup2(fd, STDOUT_FILENO);
-			close(fd);
-		}
-		else if (current->op_type == OP_REDIR_APPEND)
-		{
-			fd = open(current->file, O_WRONLY | O_CREAT | O_APPEND, 0644);
-			if (fd == -1)
-				return (-1);
-			dup2(fd, STDOUT_FILENO);
-			close(fd);
-		}
-		current = current->next;
-	}
-	return (0);
-}
-
-void	cmd_exec_inline(int argc, char **argv, t_env *env, t_cmd *cmd)
-{
-	if (argc == 3 && argv[1] && ft_strncmp(argv[1], "-c", 3) == 0)
-	{
-		cmd_init(argv[2], cmd, env);
-		cmd_exec(cmd, env);
-		free_cmd(cmd);
-		env_free(env);
-		exit(g_signal);
-	}
-	else if (argc > 1)
-	{
-		printf("Usage:\n./minishell\nOR\n./minishell -c \"command\"\n");
-		g_signal = 2;
-	}
-}
-
-static void handle_redirections(t_cmdblock *block, int *pipefd, int *fd_output)
-{
-	t_redirect *redir;
-
-	*fd_output = STDOUT_FILENO;
-	if (block->redirects)
-	{
-		if (block->next)
-			close(pipefd[1]);
-		redir = block->redirects;
-		while (redir)
-		{
-			if (redir->op_type == OP_REDIR_OUT)
-				*fd_output = open(redir->file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-			else if (redir->op_type == OP_REDIR_APPEND)
-				*fd_output = open(redir->file, O_WRONLY | O_CREAT | O_APPEND, 0644);
-			redir = redir->next;
-		}
-	}
-	else if (block->next)
-		*fd_output = pipefd[1];
-}
-
-static void handle_pipe_setup(t_cmdblock *block, int *pipefd, int *prev_pipe)
+static void	handle_pipe_setup(t_cmdblock *block, int *pipefd, int *prev_pipe)
 {
 	if (*prev_pipe != STDIN_FILENO)
 		close(*prev_pipe);
@@ -157,7 +32,8 @@ static void	exec_piped_cmd(t_cmd *cmd, t_env *env,
 
 	if (cmd_setup(cmd, env, &args, &full_path) != 0)
 		exit(g_signal);
-	if (cmd->cmd->redirects && setup_redirections(cmd->cmd->redirects) == -1)
+	if (cmd->cmd->redirects
+		&& cmd_exec_setup_redirect(cmd->cmd->redirects) == -1)
 	{
 		perror("redirect error");
 		exit(1);
@@ -207,7 +83,7 @@ int	cmd_exec(t_cmd *cmd, t_env *env)
 		}
 		if (get_builtin(cmdtmp->cmd->exec))
 		{
-			handle_redirections(cmdtmp->cmd, pipefd, &fd_output);
+			cmd_exec_handle_redirect(cmdtmp->cmd, pipefd, &fd_output);
 			result = execute_builtin(cmdtmp, env, prev_pipe, fd_output);
 			if (fd_output != STDOUT_FILENO && fd_output != pipefd[1])
 				close(fd_output);
@@ -228,9 +104,7 @@ int	cmd_exec(t_cmd *cmd, t_env *env)
 					close(pipefd[0]);
 				}
 				else
-				{
 					exec_piped_cmd(cmdtmp, env, prev_pipe, STDOUT_FILENO);
-				}
 			}
 		}
 		handle_pipe_setup(cmdtmp->cmd, pipefd, &prev_pipe);

--- a/src/command/cmd_exec.c
+++ b/src/command/cmd_exec.c
@@ -12,51 +12,67 @@
 
 #include "minishell.h"
 
-static void	handle_pipe_setup(t_cmdblock *block, int *pipefd, int *prev_pipe)
+static int	handle_builtin_cmd(t_cmd *cmdtmp, t_env *env,
+							int *pipefd, int *prev_pipe)
 {
-	if (*prev_pipe != STDIN_FILENO)
-		close(*prev_pipe);
-	if (block->next)
-	{
-		close(pipefd[1]);
-		*prev_pipe = pipefd[0];
-	}
+	int	fd_output;
+	int	result;
+
+	fd_output = STDOUT_FILENO;
+	cmd_exec_handle_redirect(cmdtmp->cmd, pipefd, &fd_output);
+	result = execute_builtin(cmdtmp, env, *prev_pipe, fd_output);
+	if (fd_output != STDOUT_FILENO && fd_output != pipefd[1])
+		close(fd_output);
+	return (result);
 }
 
-static void	exec_piped_cmd(t_cmd *cmd, t_env *env,
-									int input_fd, int output_fd)
+static int	handle_external_cmd(t_cmd *cmdtmp, t_env *env,
+							int *pipefd, int prev_pipe)
 {
-	char			*full_path;
-	char			**args;
-	char			**env_array;
+	pid_t	pid;
 
-	if (cmd_setup(cmd, env, &args, &full_path) != 0)
-		exit(g_signal);
-	if (cmd->cmd->redirects
-		&& cmd_exec_setup_redirect(cmd->cmd->redirects) == -1)
+	pid = fork();
+	if (pid == -1)
 	{
-		perror("redirect error");
-		exit(1);
+		perror("fork");
+		return (1);
 	}
-	if (input_fd != STDIN_FILENO)
+	if (pid == 0)
 	{
-		dup2(input_fd, STDIN_FILENO);
-		close(input_fd);
+		if (cmdtmp->cmd->next)
+		{
+			cmd_exec_pipe_cmd(cmdtmp, env, prev_pipe, pipefd[1]);
+			close(pipefd[0]);
+		}
+		else
+			cmd_exec_pipe_cmd(cmdtmp, env, prev_pipe, STDOUT_FILENO);
 	}
-	if (output_fd != STDOUT_FILENO)
+	return (0);
+}
+
+static int	execute_command(t_cmd *cmdtmp, t_env *env,
+							int *pipefd, int *prev_pipe)
+{
+	int	result;
+
+	result = 0;
+	if (get_builtin(cmdtmp->cmd->exec))
+		result = handle_builtin_cmd(cmdtmp, env, pipefd, prev_pipe);
+	else if (handle_external_cmd(cmdtmp, env, pipefd, *prev_pipe))
+		return (1);
+	cmd_exec_setup_pipe(cmdtmp->cmd, pipefd, prev_pipe);
+	return (result);
+}
+
+static void	update_command_position(t_cmd **cmdtmp)
+{
+	if (!(*cmdtmp)->cmd->next)
 	{
-		dup2(output_fd, STDOUT_FILENO);
-		close(output_fd);
+		if ((*cmdtmp)->cmd->prev)
+			(*cmdtmp)->cmd = (*cmdtmp)->cmd->prev;
+		return ;
 	}
-	env_array = env_to_array(env);
-	execve(full_path, args, env_array);
-	free_array(env_array);
-	free_array(args);
-	free_cmd(cmd);
-	env_free(env);
-	free(full_path);
-	perror("execve error");
-	exit(1);
+	(*cmdtmp)->cmd = (*cmdtmp)->cmd->next;
 }
 
 int	cmd_exec(t_cmd *cmd, t_env *env)
@@ -64,64 +80,24 @@ int	cmd_exec(t_cmd *cmd, t_env *env)
 	int			pipefd[2];
 	int			prev_pipe;
 	int			result;
-	pid_t		pid;
 	t_cmd		*cmdtmp;
-	int			fd_output;
 
 	result = 0;
 	prev_pipe = STDIN_FILENO;
-	fd_output = STDOUT_FILENO;
 	pipefd[0] = -1;
 	pipefd[1] = -1;
 	cmdtmp = cmd;
 	while (cmdtmp->cmd)
 	{
-		if (cmdtmp->cmd->next && pipe(pipefd) == -1)
-		{
-			perror("pipe");
+		if (cmd_exec_pipe_check(cmdtmp, pipefd))
 			return (1);
-		}
-		if (get_builtin(cmdtmp->cmd->exec))
-		{
-			cmd_exec_handle_redirect(cmdtmp->cmd, pipefd, &fd_output);
-			result = execute_builtin(cmdtmp, env, prev_pipe, fd_output);
-			if (fd_output != STDOUT_FILENO && fd_output != pipefd[1])
-				close(fd_output);
-		}
-		else
-		{
-			pid = fork();
-			if (pid == -1)
-			{
-				perror("fork");
-				return (1);
-			}
-			else if (pid == 0)
-			{
-				if (cmdtmp->cmd->next)
-				{
-					exec_piped_cmd(cmdtmp, env, prev_pipe, pipefd[1]);
-					close(pipefd[0]);
-				}
-				else
-					exec_piped_cmd(cmdtmp, env, prev_pipe, STDOUT_FILENO);
-			}
-		}
-		handle_pipe_setup(cmdtmp->cmd, pipefd, &prev_pipe);
+		result = execute_command(cmdtmp, env, pipefd, &prev_pipe);
+		if (result == 1)
+			return (1);
+		update_command_position(&cmdtmp);
 		if (!cmdtmp->cmd->next)
-		{
-			if (cmdtmp->cmd->prev)
-				cmdtmp->cmd = cmdtmp->cmd->prev;
 			break ;
-		}
-		cmdtmp->cmd = cmdtmp->cmd->next;
 	}
-	while (wait(&result) > 0)
-	{
-		if (WIFEXITED(result))
-			g_signal = WEXITSTATUS(result);
-		else if (WIFSIGNALED(result))
-			g_signal = WTERMSIG(result) + 128;
-	}
+	cmd_exec_pipe_wait_children(&result);
 	return (WEXITSTATUS(result));
 }

--- a/src/command/cmd_exec.c
+++ b/src/command/cmd_exec.c
@@ -64,15 +64,16 @@ static int	execute_command(t_cmd *cmdtmp, t_env *env,
 	return (result);
 }
 
-static void	update_command_position(t_cmd **cmdtmp)
+static int	update_command_position(t_cmd **cmdtmp)
 {
 	if (!(*cmdtmp)->cmd->next)
 	{
 		if ((*cmdtmp)->cmd->prev)
 			(*cmdtmp)->cmd = (*cmdtmp)->cmd->prev;
-		return ;
+		return (1);
 	}
 	(*cmdtmp)->cmd = (*cmdtmp)->cmd->next;
+	return (0);
 }
 
 int	cmd_exec(t_cmd *cmd, t_env *env)
@@ -94,8 +95,7 @@ int	cmd_exec(t_cmd *cmd, t_env *env)
 		result = execute_command(cmdtmp, env, pipefd, &prev_pipe);
 		if (result == 1)
 			return (1);
-		update_command_position(&cmdtmp);
-		if (!cmdtmp->cmd->next)
+		if (update_command_position(&cmdtmp))
 			break ;
 	}
 	cmd_exec_pipe_wait_children(&result);

--- a/src/command/cmd_exec_heredoc.c
+++ b/src/command/cmd_exec_heredoc.c
@@ -1,0 +1,61 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cmd_exec_heredoc.c                                 :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: julio.formiga <julio.formiga@gmail.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/24 17:12:25 by julio.formiga     #+#    #+#             */
+/*   Updated: 2025/01/24 17:12:25 by julio.formiga    ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+int	cmd_exec_handle_heredoc(char *delimiter)
+{
+	int		pipe_fd[2];
+	char	*line;
+	size_t	delim_len;
+
+	if (pipe(pipe_fd) == -1)
+		return (-1);
+	delim_len = ft_strlen(delimiter);
+	while (1)
+	{
+		line = readline("pipe heredoc> ");
+		if (!line)
+		{
+			close(pipe_fd[1]);
+			return (-1);
+		}
+		if (ft_strlen(line) == delim_len && ft_strcmp(line, delimiter) == 0)
+		{
+			free(line);
+			break ;
+		}
+		write(pipe_fd[1], line, ft_strlen(line));
+		write(pipe_fd[1], "\n", 1);
+		free(line);
+	}
+	return (close(pipe_fd[1]), pipe_fd[0]);
+}
+
+int	cmd_exec_setup_heredoc(t_redirect *redirects, int *heredoc_fd)
+{
+	t_redirect	*current;
+
+	*heredoc_fd = -1;
+	current = redirects;
+	while (current)
+	{
+		if (current->op_type == OP_HEREDOC)
+		{
+			*heredoc_fd = cmd_exec_handle_heredoc(current->file);
+			if (*heredoc_fd == -1)
+				return (-1);
+		}
+		current = current->next;
+	}
+	return (0);
+}

--- a/src/command/cmd_exec_pipe.c
+++ b/src/command/cmd_exec_pipe.c
@@ -1,0 +1,85 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cmd_exec_pipe.c                                    :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: julio.formiga <julio.formiga@gmail.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/24 17:28:02 by julio.formiga     #+#    #+#             */
+/*   Updated: 2025/01/24 17:28:02 by julio.formiga    ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static void	setup_pipe_fds(int input_fd, int output_fd)
+{
+	if (input_fd != STDIN_FILENO)
+	{
+		dup2(input_fd, STDIN_FILENO);
+		close(input_fd);
+	}
+	if (output_fd != STDOUT_FILENO)
+	{
+		dup2(output_fd, STDOUT_FILENO);
+		close(output_fd);
+	}
+}
+
+void	cmd_exec_pipe_cmd(t_cmd *cmd, t_env *env, int infd, int outfd)
+{
+	char			*full_path;
+	char			**args;
+	char			**env_array;
+
+	if (cmd_setup(cmd, env, &args, &full_path) != 0)
+		exit(g_signal);
+	if (cmd->cmd->redirects
+		&& cmd_exec_setup_redirect(cmd->cmd->redirects) == -1)
+	{
+		perror("redirect error");
+		exit(1);
+	}
+	setup_pipe_fds(infd, outfd);
+	env_array = env_to_array(env);
+	execve(full_path, args, env_array);
+	free_array(env_array);
+	free_array(args);
+	free_cmd(cmd);
+	env_free(env);
+	free(full_path);
+	perror("execve error");
+	exit(1);
+}
+
+void	cmd_exec_pipe_wait_children(int *result)
+{
+	while (wait(result) > 0)
+	{
+		if (WIFEXITED(*result))
+			g_signal = WEXITSTATUS(*result);
+		else if (WIFSIGNALED(*result))
+			g_signal = WTERMSIG(*result) + 128;
+	}
+}
+
+int	cmd_exec_pipe_check(t_cmd *cmdtmp, int *pipefd)
+{
+	if (cmdtmp->cmd->next && pipe(pipefd) == -1)
+	{
+		perror("pipe");
+		return (1);
+	}
+	return (0);
+}
+
+void	cmd_exec_setup_pipe(t_cmdblock *block, int *fd, int *prev_pipe)
+{
+	if (*prev_pipe != STDIN_FILENO)
+		close(*prev_pipe);
+	if (block->next)
+	{
+		close(fd[1]);
+		*prev_pipe = fd[0];
+	}
+}

--- a/src/command/cmd_exec_redirects.c
+++ b/src/command/cmd_exec_redirects.c
@@ -1,0 +1,122 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   cmd_exec_redirect.c                                :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: julio.formiga <julio.formiga@gmail.com>    +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2025/01/24 16:39:56 by julio.formiga     #+#    #+#             */
+/*   Updated: 2025/01/24 16:39:56 by julio.formiga    ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "minishell.h"
+
+static int	handle_heredoc(char *delimiter)
+{
+	int		pipe_fd[2];
+	char	*line;
+	size_t	delim_len;
+
+	if (pipe(pipe_fd) == -1)
+		return (-1);
+	delim_len = ft_strlen(delimiter);
+	while (1)
+	{
+		line = readline("pipe heredoc> ");
+		if (!line)
+		{
+			close(pipe_fd[1]);
+			return (-1);
+		}
+		if (ft_strlen(line) == delim_len && ft_strcmp(line, delimiter) == 0)
+		{
+			free(line);
+			break ;
+		}
+		write(pipe_fd[1], line, ft_strlen(line));
+		write(pipe_fd[1], "\n", 1);
+		free(line);
+	}
+	return (close(pipe_fd[1]), pipe_fd[0]);
+}
+
+void	cmd_exec_handle_redirect(t_cmdblock *block, int *pipefd, int *fd_output)
+{
+	t_redirect	*redir;
+
+	*fd_output = STDOUT_FILENO;
+	if (block->redirects)
+	{
+		if (block->next)
+			close(pipefd[1]);
+		redir = block->redirects;
+		while (redir)
+		{
+			if (redir->op_type == OP_REDIR_OUT)
+				*fd_output = open(redir->file, O_WRONLY | O_CREAT | O_TRUNC,
+						0644);
+			else if (redir->op_type == OP_REDIR_APPEND)
+				*fd_output = open(redir->file, O_WRONLY | O_CREAT | O_APPEND,
+						0644);
+			redir = redir->next;
+		}
+	}
+	else if (block->next)
+		*fd_output = pipefd[1];
+}
+
+int	cmd_exec_setup_redirect(t_redirect *redirects)
+{
+	t_redirect	*current;
+	int			fd;
+	int			heredoc_fd;
+
+	heredoc_fd = -1;
+	current = redirects;
+	while (current)
+	{
+		if (current->op_type == OP_HEREDOC)
+		{
+			heredoc_fd = handle_heredoc(current->file);
+			if (heredoc_fd == -1)
+				return (-1);
+		}
+		current = current->next;
+	}
+	current = redirects;
+	while (current)
+	{
+		if (current->op_type == OP_REDIR_IN)
+		{
+			fd = open(current->file, O_RDONLY);
+			if (fd == -1)
+				return (-1);
+			dup2(fd, STDIN_FILENO);
+			close(fd);
+		}
+		else if (current->op_type == OP_HEREDOC)
+		{
+			dup2(heredoc_fd, STDIN_FILENO);
+			close(heredoc_fd);
+		}
+		else if (current->op_type == OP_REDIR_OUT)
+		{
+			fd = open(current->file, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+			if (fd == -1)
+				return (-1);
+			dup2(fd, STDOUT_FILENO);
+			close(fd);
+		}
+		else if (current->op_type == OP_REDIR_APPEND)
+		{
+			fd = open(current->file, O_WRONLY | O_CREAT | O_APPEND, 0644);
+			if (fd == -1)
+				return (-1);
+			dup2(fd, STDOUT_FILENO);
+			close(fd);
+		}
+		current = current->next;
+	}
+	return (0);
+}

--- a/src/command/cmd_init.c
+++ b/src/command/cmd_init.c
@@ -12,37 +12,38 @@
 
 #include "minishell.h"
 
-int	cmd_setup(t_cmd *cmd, t_env *env, char ***args, char **full_path)
+static int	setup_null_args(char ***args, char **full_path)
 {
-	int	i;
-
-	*full_path = cmd_check(cmd, env);
-	if (!*full_path)
-		return (g_signal);
-	if (!cmd->cmd || !cmd->cmd->exec)
-		return (1);
-	if (cmd->cmd->args == NULL)
-	{
-		*args = malloc(sizeof(char *) * 2);
-		if (!*args)
-			return (1);
-		(*args)[0] = ft_strdup(*full_path);
-		if (!(*args)[0])
-		{
-			free(*args);
-			return (1);
-		}
-		(*args)[1] = NULL;
-		return (0);
-	}
-	*args = malloc(sizeof(char *) * (ft_array_len(cmd->cmd->args) + 2));
+	*args = malloc(sizeof(char *) * 2);
 	if (!*args)
 		return (1);
 	(*args)[0] = ft_strdup(*full_path);
-	i = -1;
-	while (cmd->cmd->args[++i])
+	if (!(*args)[0])
 	{
-		(*args)[i + 1] = ft_strdup(cmd->cmd->args[i]);
+		free(*args);
+		return (1);
+	}
+	(*args)[1] = NULL;
+	return (0);
+}
+
+static int	setup_args_copy(char ***args, char **cmd_args, char *full_path)
+{
+	int	i;
+
+	*args = malloc(sizeof(char *) * (ft_array_len(cmd_args) + 2));
+	if (!*args)
+		return (1);
+	(*args)[0] = ft_strdup(full_path);
+	if (!(*args)[0])
+	{
+		free(*args);
+		return (1);
+	}
+	i = -1;
+	while (cmd_args[++i])
+	{
+		(*args)[i + 1] = ft_strdup(cmd_args[i]);
 		if (!(*args)[i + 1])
 		{
 			while (i >= 0)
@@ -53,6 +54,18 @@ int	cmd_setup(t_cmd *cmd, t_env *env, char ***args, char **full_path)
 	}
 	(*args)[i + 1] = NULL;
 	return (0);
+}
+
+int	cmd_setup(t_cmd *cmd, t_env *env, char ***args, char **full_path)
+{
+	*full_path = cmd_check(cmd, env);
+	if (!*full_path)
+		return (g_signal);
+	if (!cmd->cmd || !cmd->cmd->exec)
+		return (1);
+	if (cmd->cmd->args == NULL)
+		return (setup_null_args(args, full_path));
+	return (setup_args_copy(args, cmd->cmd->args, *full_path));
 }
 
 void	cmd_init(char *rl, t_cmd *cmd, t_env *env)

--- a/src/command/cmd_utils.c
+++ b/src/command/cmd_utils.c
@@ -12,31 +12,21 @@
 
 #include "minishell.h"
 
-char	**env_to_array(t_env *env)
+void	cmd_exec_inline(int argc, char **argv, t_env *env, t_cmd *cmd)
 {
-	char	**env_array;
-	t_env	*current;
-	char	*tmp;
-	int		i;
-
-	i = -1;
-	current = env;
-	while (i++, current)
-		current = current->next;
-	env_array = malloc(sizeof(char *) * (i + 1));
-	if (!env_array)
-		return (NULL);
-	current = env;
-	i = -1;
-	while (i++, current)
+	if (argc == 3 && argv[1] && ft_strncmp(argv[1], "-c", 3) == 0)
 	{
-		tmp = ft_strjoin(current->key, "=");
-		env_array[i] = ft_strjoin(tmp, current->value);
-		free(tmp);
-		current = current->next;
+		cmd_init(argv[2], cmd, env);
+		cmd_exec(cmd, env);
+		free_cmd(cmd);
+		env_free(env);
+		exit(g_signal);
 	}
-	env_array[i] = NULL;
-	return (env_array);
+	else if (argc > 1)
+	{
+		printf("Usage:\n./minishell\nOR\n./minishell -c \"command\"\n");
+		g_signal = 2;
+	}
 }
 
 t_cmdblock	*get_first_block(t_cmdblock *block)


### PR DESCRIPTION
This pull request includes significant changes to the `minishell` project, focusing on refactoring and enhancing the command execution, handling of environment variables, and redirections. The most important changes include the addition of new functions for handling pipes and redirections, refactoring of existing functions to improve readability and maintainability, and the relocation of some functions to more appropriate files.

### Refactoring and Enhancements:

* **Command Execution Enhancements:**
  - Added new functions for handling pipes (`cmd_exec_pipe_cmd`, `cmd_exec_pipe_wait_children`, `cmd_exec_pipe_check`, `cmd_exec_setup_pipe`) to `src/command/cmd_exec_pipe.c`.
  - Refactored the command execution flow in `src/command/cmd_exec.c` to use the new pipe handling functions and improve readability.

* **Redirections Handling:**
  - Added new functions for handling redirections (`cmd_exec_handle_redirect`, `cmd_exec_setup_redirect`) to `src/command/cmd_exec_redirects.c`.
  - Moved the heredoc handling to a new file `src/command/cmd_exec_heredoc.c` and added functions `cmd_exec_handle_heredoc` and `cmd_exec_setup_heredoc`.

* **Environment Variables Management:**
  - Moved `env_unset` function from `src/builtin/env.c` to a new file `src/builtin/unset.c`.
  - Added a new function `env_to_array` to `src/builtin/env.c` for converting environment variables to an array.

* **Code Structure Improvements:**
  - Refactored `cmd_setup` function in `src/command/cmd_init.c` by splitting it into smaller helper functions (`setup_null_args`, `setup_args_copy`). [[1]](diffhunk://#diff-32102f3c5e137750af09faf560bc45f3b4adad505b054d9feec8402818b24276L15-R15) [[2]](diffhunk://#diff-32102f3c5e137750af09faf560bc45f3b4adad505b054d9feec8402818b24276L38-R46) [[3]](diffhunk://#diff-32102f3c5e137750af09faf560bc45f3b4adad505b054d9feec8402818b24276R59-R70)
  - Improved the structure of `typedef enum e_operator` and `typedef struct s_redirect` in `include/minishell.h` for better readability. [[1]](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL42-R43) [[2]](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL51-R53)

These changes collectively enhance the maintainability, readability, and functionality of the `minishell` project.