### PR TITLE
fixed > without quotes

### DIFF
--- a/test/test_minishell.cpp
+++ b/test/test_minishell.cpp
@@ -189,6 +189,18 @@ TEST_F(MinishellTest, SpecialCharacters) {
 //     ASSERT_EQ(result.stdout_output, "1$ $ c c $c  c $ac  ''  c") << "Shell should go to hell";
 // }
 
+// TEST_F(MinishellTest, emptyRedirect) {
+//     string command = "echo >" + shell_path;
+//     CommandOutput result = exec_command(command);
+//     ASSERT_EQ(result.stdout_output, "") << "Shell should return empty line and no leaks";
+// }
+
+// TEST_F(MinishellTest, emptyRedirectAndSpace) {
+//     string command = "echo > " + shell_path;
+//     CommandOutput result = exec_command(command);
+//     ASSERT_EQ(result.stdout_output, "") << "Shell should return empty line and no leaks";
+// }
+
 int main(int argc, char **argv) {
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Fixed code for following use cases, no leak:

echo > (no space after >)
echo > (space after >)
echo >file.txt hello
echo > file.txt hello
echo "a"b
echo a"b"