### PR TITLE
Fix/parser redirect null

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -118,7 +118,7 @@ int				cmd_setup(t_cmd *cmd, t_env *env, char ***args,
 void			cmd_init(char *rl, t_cmd *cmd, t_env *env);
 void			cmd_exec_inline(int argc, char **argv, t_env *env, t_cmd *cmd);
 void			cmd_exec_setup_pipe(t_cmdblock *block, int *fd, int *prev_pipe);
-void			cmd_exec_handle_redirect(t_cmdblock *block,
+int				cmd_exec_handle_redirect(t_cmdblock *block,
 					int *pipefd, int *fd_output);
 int				cmd_exec_handle_heredoc(char *delimiter);
 int				cmd_exec_setup_redirect(t_redirect *redirects);

--- a/src/command/cmd_exec.c
+++ b/src/command/cmd_exec.c
@@ -19,7 +19,9 @@ static int	handle_builtin_cmd(t_cmd *cmdtmp, t_env *env,
 	int	result;
 
 	fd_output = STDOUT_FILENO;
-	cmd_exec_handle_redirect(cmdtmp->cmd, pipefd, &fd_output);
+	result = cmd_exec_handle_redirect(cmdtmp->cmd, pipefd, &fd_output);
+	if (result)
+		return (result);
 	result = execute_builtin(cmdtmp, env, *prev_pipe, fd_output);
 	if (fd_output != STDOUT_FILENO && fd_output != pipefd[1])
 		close(fd_output);

--- a/src/command/cmd_exec_redirects.c
+++ b/src/command/cmd_exec_redirects.c
@@ -17,7 +17,7 @@ static	int	cmd_exec_check_file(char *file)
 	if (file[0] == '\0')
 	{
 		perror("minishell: syntax error near unexpected token `newline'");
-		return (g_signal = 2, 2);
+		return (2);
 	}
 	return (0);
 }

--- a/src/command/cmd_exec_redirects.c
+++ b/src/command/cmd_exec_redirects.c
@@ -12,7 +12,17 @@
 
 #include "minishell.h"
 
-void	cmd_exec_handle_redirect(t_cmdblock *block, int *pipefd, int *fd_output)
+static	int	cmd_exec_check_file(char *file)
+{
+	if (file[0] == '\0')
+	{
+		perror("minishell: syntax error near unexpected token `newline'");
+		return (g_signal = 2, 2);
+	}
+	return (0);
+}
+
+int	cmd_exec_handle_redirect(t_cmdblock *block, int *pipefd, int *fd_output)
 {
 	t_redirect	*redir;
 
@@ -24,6 +34,8 @@ void	cmd_exec_handle_redirect(t_cmdblock *block, int *pipefd, int *fd_output)
 		redir = block->redirects;
 		while (redir)
 		{
+			if (cmd_exec_check_file(redir->file))
+				return (g_signal = 2, 2);
 			if (redir->op_type == OP_REDIR_OUT)
 				*fd_output = open(redir->file, O_WRONLY | O_CREAT | O_TRUNC,
 						0644);
@@ -35,6 +47,7 @@ void	cmd_exec_handle_redirect(t_cmdblock *block, int *pipefd, int *fd_output)
 	}
 	else if (block->next)
 		*fd_output = pipefd[1];
+	return (0);
 }
 
 static int	setup_input_redirect(t_redirect *current, int *fd)

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -261,6 +261,7 @@ void	cmd_parser(char *rl, t_cmd *cmd, t_env *env)
 		}
 		free(cmd_parts[i]);
 		cmd_parts[i] = expanded;
+		// printf("cmd_parts[%d]: %s\n", i, cmd_parts[i]);
 		//if (is_operator_start(cmd_parts[i][0]))
 		if (get_operator_type(cmd_parts[i]) != OP_NONE)//controllo redirect problematico
 		{
@@ -277,11 +278,11 @@ void	cmd_parser(char *rl, t_cmd *cmd, t_env *env)
 			}
 			else if (i + 1 < count_tokens(rl))
 			{
-				i++;
-				if (!cmd_parts[i])//protegge da echo >
-					break ;
-				file = parser_expansion(cmd_parts[i], env);
-				if (!file || !add_redirect(current, op_type, file))
+				if (cmd_parts[i + 1])
+					file = parser_expansion(cmd_parts[++i], env);
+				else
+					file = ft_strdup("");
+				if (!add_redirect(current, op_type, file))
 				{
 					free(file);
 					break ;

--- a/src/parser/parser_redirects.c
+++ b/src/parser/parser_redirects.c
@@ -25,12 +25,9 @@ static t_redirect	*create_redirect(t_operator type, char *file)
 	if (!redir)
 		return (NULL);
 	redir->op_type = type;
-	redir->file = ft_strdup(file);
-	if (!redir->file)
-	{
-		free(redir);
-		return (NULL);
-	}
+	redir->file = NULL;
+	if (file)
+		redir->file = ft_strdup(file);
 	redir->next = NULL;
 	return (redir);
 }

--- a/test/test_minishell.cpp
+++ b/test/test_minishell.cpp
@@ -189,6 +189,19 @@ TEST_F(MinishellTest, SpecialCharacters) {
 //     ASSERT_EQ(result.stdout_output, "1$ $ c c $c  c $ac  ''  c") << "Shell should go to hell";
 // }
 
+TEST_F(MinishellTest, EmptyRedirect) {
+    string command = shell_path + " -c 'echo >'";
+    CommandOutput result = exec_command(command);
+
+    ASSERT_FALSE(result.stderr_output.empty())
+        << "Invalid command should produce error output";
+    ASSERT_TRUE(result.stderr_output.find("unexpected token") != string::npos &&
+                result.stderr_output.find("error") != string::npos)
+        << "Error message should indicate command not found";
+	ASSERT_EQ(result.exit_code, 2)
+		<< "Invalid command should set exit status to 2";
+}
+
 // TEST_F(MinishellTest, emptyRedirect) {
 //     string command = "echo >" + shell_path;
 //     CommandOutput result = exec_command(command);


### PR DESCRIPTION
This pull request includes several changes to improve error handling for command redirection in the `minishell` project. The modifications ensure that invalid redirection commands are properly detected and reported, and they introduce new tests to verify the behavior.

### Error Handling Improvements:
* [`include/minishell.h`](diffhunk://#diff-471850465338484d65e05947dade7a795e3e068ed9502a098e77c91b5ac1582fL121-R121): Changed the return type of `cmd_exec_handle_redirect` from `void` to `int` to indicate error status.
* [`src/command/cmd_exec.c`](diffhunk://#diff-a19626c0ef195227ffa003fbbd4f82f4c1f73754ce6c44dfc41f210ec88d73beL22-R24): Updated `handle_builtin_cmd` to check the return value of `cmd_exec_handle_redirect` and return the error status if an error is detected.
* [`src/command/cmd_exec_redirects.c`](diffhunk://#diff-61c46388087269c6b48c331c7b074c1b58217bec7157fe48029012f73bc3ffb9L15-R25): Added a new function `cmd_exec_check_file` to validate file names for redirection. Updated `cmd_exec_handle_redirect` to return an error status if `cmd_exec_check_file` detects an invalid file. [[1]](diffhunk://#diff-61c46388087269c6b48c331c7b074c1b58217bec7157fe48029012f73bc3ffb9L15-R25) [[2]](diffhunk://#diff-61c46388087269c6b48c331c7b074c1b58217bec7157fe48029012f73bc3ffb9R37-R38) [[3]](diffhunk://#diff-61c46388087269c6b48c331c7b074c1b58217bec7157fe48029012f73bc3ffb9R50)

### Parser Adjustments:
* [`src/parser/parser.c`](diffhunk://#diff-a07f146eb89913dc369f69ee0108bc864842ce31211a05b121e5c3c432cdb16eL280-R285): Modified `cmd_parser` to handle cases where the file name for redirection is empty, ensuring proper error handling and preventing crashes.
* [`src/parser/parser_redirects.c`](diffhunk://#diff-e66f254aca234aa95de3539eff65fd48f95fce1da881d76990175df9cf2fc671R28-L33): Updated `create_redirect` to initialize the `file` member to `NULL` and to handle cases where `file` is `NULL` gracefully.

### Testing:
* [`test/test_minishell.cpp`](diffhunk://#diff-fee842cb1d43ff459d675e20d0c3ac92fd73f8da8cf0f842eb1b2d5ade4c2dfeR192-R204): Added a new test `EmptyRedirect` to verify that invalid redirection commands produce appropriate error messages and exit statuses.