### PR TITLE
2025 01 29  handling redirect in quotes

### DIFF
--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: scarlucc <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/30 14:35:35 by julio.formi       #+#    #+#             */
-/*   Updated: 2025/01/29 12:08:39 by scarlucc         ###   ########.fr       */
+/*   Updated: 2025/01/29 19:49:02 by scarlucc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -105,7 +105,7 @@ int				env_unset(t_env **env, char *key);
 void			env_free(t_env *env);
 
 char			*get_var_name(const char *str);
-char			**cmd_parser_readline(char *rl, t_env *env);
+char			**cmd_parser_readline(char *rl, t_env *env, int **values, int token_count);
 char			*parser_expansion(const char *str, t_env *env);
 char			*cmd_check(t_cmd *cmd, t_env *env);
 void			cmd_parser(char *rl, t_cmd *cmd, t_env *env);

--- a/include/minishell.h
+++ b/include/minishell.h
@@ -6,7 +6,7 @@
 /*   By: scarlucc <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/30 14:35:35 by julio.formi       #+#    #+#             */
-/*   Updated: 2025/01/29 19:49:02 by scarlucc         ###   ########.fr       */
+/*   Updated: 2025/01/30 11:41:02 by scarlucc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -90,6 +90,7 @@ char			*ft_strndup(const char *s1, size_t n);
 char			**env_to_array(t_env *env);
 int				ft_array_len(char **array);
 void			free_array(char **array);
+void			free_int_array(int **array);
 
 t_builtin_fn	get_builtin(char *cmd_name);
 int				execute_builtin(t_cmd *cmd, t_env *env,
@@ -105,7 +106,7 @@ int				env_unset(t_env **env, char *key);
 void			env_free(t_env *env);
 
 char			*get_var_name(const char *str);
-char			**cmd_parser_readline(char *rl, t_env *env, int **values, int token_count);
+char			**cmd_parser_readline(char *rl, t_env *env, int *values, int token_count);
 char			*parser_expansion(const char *str, t_env *env);
 char			*cmd_check(t_cmd *cmd, t_env *env);
 void			cmd_parser(char *rl, t_cmd *cmd, t_env *env);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: scarlucc <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: Invalid date        by                   #+#    #+#             */
-/*   Updated: 2025/01/29 17:52:02 by scarlucc         ###   ########.fr       */
+/*   Updated: 2025/01/29 19:49:40 by scarlucc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -145,16 +145,18 @@ static char	*extract_word(char **rl, t_env *env)
 	return (token);
 }
 
-char	**cmd_parser_readline(char *rl, t_env *env)
+char	**cmd_parser_readline(char *rl, t_env *env, int **values, int token_count)
 {
 	char	**tokens;
 	char	*token;
 	char	*tmp;
-	int		token_count;
+	//int		token_count;
 	int		i;
 
-	token_count = count_tokens(rl);
+	//token_count = count_tokens(rl);
 	tokens = malloc(sizeof(char *) * (token_count + 1));
+	//values = malloc(sizeof(int) * (token_count + 1));
+	//ft_bzero(values, token_count);
 	if (!tokens)
 		return (NULL);
 	i = 0;
@@ -174,6 +176,7 @@ char	**cmd_parser_readline(char *rl, t_env *env)
 			if (tokens[i])
 				free(tokens[i]);
 			tokens[i] = tmp;
+			*values[i] = 1;
 			if (*rl && !ft_isspace(*rl))
 				tokens[++i] = ft_strdup("");
 			free(token);
@@ -245,8 +248,13 @@ void	cmd_parser(char *rl, t_cmd *cmd, t_env *env)
 	int			arg_count;
 	int			i;
 	int			j;
+	int			*values;
+	int			n_tokens;
 
-	cmd_parts = cmd_parser_readline(rl, env);
+	n_tokens = count_tokens(rl);
+	values = malloc(sizeof(int) * (n_tokens + 1));
+	ft_bzero(values, n_tokens);
+	cmd_parts = cmd_parser_readline(rl, env, &values, n_tokens);
 	if (!cmd_parts)
 	{
 		free(cmd->cmd_line);
@@ -263,8 +271,7 @@ void	cmd_parser(char *rl, t_cmd *cmd, t_env *env)
 	i = 0;
 	while (cmd_parts[i])
 	{
-		//expanded = parser_expansion(cmd_parts[i], env);
-		expanded = ft_strdup(cmd_parts[i]);//expansion bypass, cancel after moving expansion to cmd_parser_readline
+		expanded = ft_strdup(cmd_parts[i]);
 		if (!expanded)
 		{
 			free_array(cmd_parts);
@@ -274,7 +281,7 @@ void	cmd_parser(char *rl, t_cmd *cmd, t_env *env)
 		cmd_parts[i] = ft_strdup(expanded);//il problema e' qui. Rimuovere dopo spostamento expansion
 		free(expanded);//Rimuovere dopo spostamento expansion
 		//if (is_operator_start(cmd_parts[i][0]))//vecchia condizione per controllo redirect problematico
-		if (/* str[i] != 0 && */get_operator_type(cmd_parts[i]) != OP_NONE)//controllo redirect problematico
+		if ((values[i] == 1) && get_operator_type(cmd_parts[i]) != OP_NONE)//controllo redirect problematico
 		{
 			op_type = get_operator_type(cmd_parts[i]);
 			if (op_type == OP_PIPE)

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: scarlucc <marvin@42.fr>                    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: Invalid date        by                   #+#    #+#             */
-/*   Updated: 2025/01/29 19:49:40 by scarlucc         ###   ########.fr       */
+/*   Updated: 2025/01/30 14:01:55 by scarlucc         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,11 +40,12 @@ static int	count_tokens(char *rl)
 			else if (*rl == '>' && *(rl + 1) == '>')
 				rl++;
 			rl++;
-			count++;
+			//se non ho gia' contato questo carattere
+			//count++;
+			continue;
 		}
-		/* else */
-			while (*rl && !ft_isspace(*rl) && !is_operator_start(*rl))
-				rl++;
+		while (*rl && !ft_isspace(*rl) && !is_operator_start(*rl))
+			rl++;
 	}
 	return (count);
 }
@@ -145,7 +146,7 @@ static char	*extract_word(char **rl, t_env *env)
 	return (token);
 }
 
-char	**cmd_parser_readline(char *rl, t_env *env, int **values, int token_count)
+char	**cmd_parser_readline(char *rl, t_env *env, int *values, int token_count)
 {
 	char	**tokens;
 	char	*token;
@@ -155,8 +156,6 @@ char	**cmd_parser_readline(char *rl, t_env *env, int **values, int token_count)
 
 	//token_count = count_tokens(rl);
 	tokens = malloc(sizeof(char *) * (token_count + 1));
-	//values = malloc(sizeof(int) * (token_count + 1));
-	//ft_bzero(values, token_count);
 	if (!tokens)
 		return (NULL);
 	i = 0;
@@ -176,7 +175,7 @@ char	**cmd_parser_readline(char *rl, t_env *env, int **values, int token_count)
 			if (tokens[i])
 				free(tokens[i]);
 			tokens[i] = tmp;
-			*values[i] = 1;
+			values[i] = 1;
 			if (*rl && !ft_isspace(*rl))
 				tokens[++i] = ft_strdup("");
 			free(token);
@@ -252,9 +251,8 @@ void	cmd_parser(char *rl, t_cmd *cmd, t_env *env)
 	int			n_tokens;
 
 	n_tokens = count_tokens(rl);
-	values = malloc(sizeof(int) * (n_tokens + 1));
-	ft_bzero(values, n_tokens);
-	cmd_parts = cmd_parser_readline(rl, env, &values, n_tokens);
+	values = ft_calloc(n_tokens, sizeof(int));
+	cmd_parts = cmd_parser_readline(rl, env, values, n_tokens);
 	if (!cmd_parts)
 	{
 		free(cmd->cmd_line);
@@ -349,5 +347,6 @@ void	cmd_parser(char *rl, t_cmd *cmd, t_env *env)
 		i++;
 	}
 	cmd->cmd = get_first_block(current);
+	free(values);
 	free_array(cmd_parts);
 }


### PR DESCRIPTION
added int array in cmd_parser to keep track of which > are redirect operators and which are strings.

Fixed count_tokens(): it counted one token too many when redirect operator was present